### PR TITLE
Initial: change brand to link and Info navbar link to Home

### DIFF
--- a/src/__snapshots__/App.test.js.snap
+++ b/src/__snapshots__/App.test.js.snap
@@ -67,7 +67,7 @@ exports[`matches snapshot 1`] = `
             onClick={[Function]}
             style={Object {}}
           >
-            Info
+            Home
           </a>
           <a
             className="nav-link"

--- a/src/__snapshots__/App.test.js.snap
+++ b/src/__snapshots__/App.test.js.snap
@@ -11,9 +11,16 @@ exports[`matches snapshot 1`] = `
     <div
       className="container"
     >
-      <h1
-        className="navbar-brand"
-      />
+      <a
+        className="active"
+        href="/"
+        onClick={[Function]}
+        style={Object {}}
+      >
+        <h1
+          className="navbar-brand"
+        />
+      </a>
       <button
         aria-controls="responsive-navbar-nav"
         aria-label="Toggle navigation"

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -19,7 +19,7 @@ const Navbar = ({ name }) => {
         </Nav>
         <Nav>
           <LinkContainer to='/'>
-            <Nav.Link>Info</Nav.Link>
+            <Nav.Link>Home</Nav.Link>
           </LinkContainer>
           <LinkContainer to='/projects'>
             <Nav.Link>Projects</Nav.Link>

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -10,7 +10,9 @@ const Navbar = ({ name }) => {
   return (
     <BSNavbar data-testid="navbar" collapseOnSelect expand="sm" variant="custom" fixed="top">
       <Container>
-      <BSNavbar.Brand as="h1">{name}</BSNavbar.Brand>
+        <LinkContainer to='/'>
+          <a><BSNavbar.Brand as="h1">{name}</BSNavbar.Brand></a>
+        </LinkContainer>
       <BSNavbar.Toggle aria-controls="responsive-navbar-nav"><FontAwesomeIcon icon={faBars} /></BSNavbar.Toggle>
       <BSNavbar.Collapse id="responsive-navbar-nav">
         <Nav className="me-auto">

--- a/src/components/Navbar/__snapshots__/Navbar.test.js.snap
+++ b/src/components/Navbar/__snapshots__/Navbar.test.js.snap
@@ -66,7 +66,7 @@ exports[`matches snapshot 1`] = `
           onClick={[Function]}
           style={Object {}}
         >
-          Info
+          Home
         </a>
         <a
           className="nav-link"

--- a/src/components/Navbar/__snapshots__/Navbar.test.js.snap
+++ b/src/components/Navbar/__snapshots__/Navbar.test.js.snap
@@ -8,11 +8,18 @@ exports[`matches snapshot 1`] = `
   <div
     className="container"
   >
-    <h1
-      className="navbar-brand"
+    <a
+      className="active"
+      href="/"
+      onClick={[Function]}
+      style={Object {}}
     >
-      Bacon Tester Ipsum
-    </h1>
+      <h1
+        className="navbar-brand"
+      >
+        Bacon Tester Ipsum
+      </h1>
+    </a>
     <button
       aria-controls="responsive-navbar-nav"
       aria-label="Toggle navigation"


### PR DESCRIPTION
This update changes 2 things:

- The `<Navbar.Brand>` `<h1>` is now wrapped in an `<a>` wrapped in a `<Link.Container>` and links to '/'.
- The `<Nav.Link>` text 'Info' is now 'Home'.